### PR TITLE
fix: window will now resize to fit contents

### DIFF
--- a/LS_GUI.py
+++ b/LS_GUI.py
@@ -168,8 +168,10 @@ class LinearStitch(wx.Frame):
 		sizer.Add(self.stackImages, 0, wx.ALL, 10)
 		sizer.Add(self.archiveImages, 0, wx.ALL, 10)
 		sizer.Add(button_horzSizer, 0, wx.ALL, 10)
-		panel.SetSizer(sizer)
+		panel.SetSizerAndFit(sizer)
 		panel.Layout()
+
+		self.SetSizerAndFit(sizer)
 
 		#event handling - button binded with functions
 		# self.Bind(wx.EVT_BUTTON, self.on_exit_button, exitbutton)


### PR DESCRIPTION
The two buttons at the bottom of the window were being perfectly cut off, forcing the user to resize the screen in order to run the processing. For new users, this could be confusing. The window will now fit these and future contents.